### PR TITLE
feat: add release profile optimizations and --locked flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,9 @@ authors = ["kurama"]
 repository = "https://github.com/kurama/dealve-tui"
 keywords = ["games", "deals", "tui", "terminal", "isthereanydeal"]
 categories = ["command-line-utilities"]
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = "s"
+strip = true

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ rustup update
 ## Installation
 
 ```bash
-cargo install dealve-tui
+cargo install --locked dealve-tui
 ```
 
 Or build from source:
@@ -42,7 +42,7 @@ Or build from source:
 ```bash
 git clone https://github.com/kurama/dealve-tui
 cd dealve-tui
-cargo install --path tui
+cargo install --locked --path tui
 ```
 
 This installs the `dealve` binary to `~/.cargo/bin/`.


### PR DESCRIPTION
Apply Ratatui recommended release profile options (codegen-units=1, lto, opt-level="s", strip) reducing binary size from ~5.8MiB to ~2.6MiB.
Add --locked flag to cargo install commands in README.

Closes #2 