### PR TITLE
ci: add aarch64-unknown-linux-gnu release build target

### DIFF
--- a/.github/workflows/release_cargo.yml
+++ b/.github/workflows/release_cargo.yml
@@ -41,6 +41,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: dealve-linux-x86_64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            name: dealve-linux-aarch64
           - target: x86_64-apple-darwin
             os: macos-latest
             name: dealve-macos-x86_64


### PR DESCRIPTION
Add Linux aarch64 build target to release workflow using native GitHub ARM runner (ubuntu-24.04-arm)

Closes #3 