### PR TITLE
feat: support all ITAD regions with continent-grouped scrollable picker

### DIFF
--- a/core/src/models.rs
+++ b/core/src/models.rs
@@ -3,75 +3,344 @@ use serde::{Deserialize, Serialize};
 /// Supported countries for deal filtering (ISO 3166-1 alpha-2 codes)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Region {
+    // Europe
+    AT,
+    BE,
+    BG,
+    CH,
+    CZ,
+    DE,
+    DK,
+    EE,
+    ES,
+    FI,
     #[default]
-    FR, // France
-    DE, // Germany
-    US, // United States
-    GB, // United Kingdom
-    CA, // Canada
-    AU, // Australia
-    IT, // Italy
-    ES, // Spain
-    PL, // Poland
-    BR, // Brazil
+    FR,
+    GB,
+    GR,
+    HR,
+    HU,
+    IE,
+    IT,
+    LT,
+    LV,
+    NL,
+    NO,
+    PL,
+    PT,
+    RO,
+    SE,
+    SK,
+    // Americas
+    AR,
+    BR,
+    CA,
+    CL,
+    CO,
+    MX,
+    US,
+    // Asia-Pacific
+    AU,
+    CN,
+    HK,
+    ID,
+    IN,
+    JP,
+    KR,
+    NZ,
+    PH,
+    SG,
+    TH,
+    TW,
+    // Middle East & Africa
+    AE,
+    IL,
+    SA,
+    TR,
+    ZA,
 }
 
 impl Region {
     pub fn name(&self) -> &str {
         match self {
-            Region::FR => "France",
+            // Europe
+            Region::AT => "Austria",
+            Region::BE => "Belgium",
+            Region::BG => "Bulgaria",
+            Region::CH => "Switzerland",
+            Region::CZ => "Czechia",
             Region::DE => "Germany",
-            Region::US => "United States",
-            Region::GB => "United Kingdom",
-            Region::CA => "Canada",
-            Region::AU => "Australia",
-            Region::IT => "Italy",
+            Region::DK => "Denmark",
+            Region::EE => "Estonia",
             Region::ES => "Spain",
+            Region::FI => "Finland",
+            Region::FR => "France",
+            Region::GB => "United Kingdom",
+            Region::GR => "Greece",
+            Region::HR => "Croatia",
+            Region::HU => "Hungary",
+            Region::IE => "Ireland",
+            Region::IT => "Italy",
+            Region::LT => "Lithuania",
+            Region::LV => "Latvia",
+            Region::NL => "Netherlands",
+            Region::NO => "Norway",
             Region::PL => "Poland",
+            Region::PT => "Portugal",
+            Region::RO => "Romania",
+            Region::SE => "Sweden",
+            Region::SK => "Slovakia",
+            // Americas
+            Region::AR => "Argentina",
             Region::BR => "Brazil",
+            Region::CA => "Canada",
+            Region::CL => "Chile",
+            Region::CO => "Colombia",
+            Region::MX => "Mexico",
+            Region::US => "United States",
+            // Asia-Pacific
+            Region::AU => "Australia",
+            Region::CN => "China",
+            Region::HK => "Hong Kong",
+            Region::ID => "Indonesia",
+            Region::IN => "India",
+            Region::JP => "Japan",
+            Region::KR => "South Korea",
+            Region::NZ => "New Zealand",
+            Region::PH => "Philippines",
+            Region::SG => "Singapore",
+            Region::TH => "Thailand",
+            Region::TW => "Taiwan",
+            // Middle East & Africa
+            Region::AE => "United Arab Emirates",
+            Region::IL => "Israel",
+            Region::SA => "Saudi Arabia",
+            Region::TR => "Turkey",
+            Region::ZA => "South Africa",
         }
     }
 
     pub fn code(&self) -> &str {
         match self {
-            Region::FR => "FR",
+            Region::AT => "AT",
+            Region::BE => "BE",
+            Region::BG => "BG",
+            Region::CH => "CH",
+            Region::CZ => "CZ",
             Region::DE => "DE",
-            Region::US => "US",
-            Region::GB => "GB",
-            Region::CA => "CA",
-            Region::AU => "AU",
-            Region::IT => "IT",
+            Region::DK => "DK",
+            Region::EE => "EE",
             Region::ES => "ES",
+            Region::FI => "FI",
+            Region::FR => "FR",
+            Region::GB => "GB",
+            Region::GR => "GR",
+            Region::HR => "HR",
+            Region::HU => "HU",
+            Region::IE => "IE",
+            Region::IT => "IT",
+            Region::LT => "LT",
+            Region::LV => "LV",
+            Region::NL => "NL",
+            Region::NO => "NO",
             Region::PL => "PL",
+            Region::PT => "PT",
+            Region::RO => "RO",
+            Region::SE => "SE",
+            Region::SK => "SK",
+            Region::AR => "AR",
             Region::BR => "BR",
+            Region::CA => "CA",
+            Region::CL => "CL",
+            Region::CO => "CO",
+            Region::MX => "MX",
+            Region::US => "US",
+            Region::AU => "AU",
+            Region::CN => "CN",
+            Region::HK => "HK",
+            Region::ID => "ID",
+            Region::IN => "IN",
+            Region::JP => "JP",
+            Region::KR => "KR",
+            Region::NZ => "NZ",
+            Region::PH => "PH",
+            Region::SG => "SG",
+            Region::TH => "TH",
+            Region::TW => "TW",
+            Region::AE => "AE",
+            Region::IL => "IL",
+            Region::SA => "SA",
+            Region::TR => "TR",
+            Region::ZA => "ZA",
         }
     }
 
+    pub fn continent(&self) -> &str {
+        match self {
+            Region::AT
+            | Region::BE
+            | Region::BG
+            | Region::CH
+            | Region::CZ
+            | Region::DE
+            | Region::DK
+            | Region::EE
+            | Region::ES
+            | Region::FI
+            | Region::FR
+            | Region::GB
+            | Region::GR
+            | Region::HR
+            | Region::HU
+            | Region::IE
+            | Region::IT
+            | Region::LT
+            | Region::LV
+            | Region::NL
+            | Region::NO
+            | Region::PL
+            | Region::PT
+            | Region::RO
+            | Region::SE
+            | Region::SK => "Europe",
+
+            Region::AR
+            | Region::BR
+            | Region::CA
+            | Region::CL
+            | Region::CO
+            | Region::MX
+            | Region::US => "Americas",
+
+            Region::AU
+            | Region::CN
+            | Region::HK
+            | Region::ID
+            | Region::IN
+            | Region::JP
+            | Region::KR
+            | Region::NZ
+            | Region::PH
+            | Region::SG
+            | Region::TH
+            | Region::TW => "Asia-Pacific",
+
+            Region::AE | Region::IL | Region::SA | Region::TR | Region::ZA => {
+                "Middle East & Africa"
+            }
+        }
+    }
+
+    /// All regions, ordered by continent then alphabetically by name
     pub const ALL: &'static [Region] = &[
+        // Europe
+        Region::AT,
+        Region::BE,
+        Region::BG,
+        Region::HR,
+        Region::CZ,
+        Region::DK,
+        Region::EE,
+        Region::FI,
         Region::FR,
         Region::DE,
-        Region::US,
-        Region::GB,
-        Region::CA,
-        Region::AU,
+        Region::GR,
+        Region::HU,
+        Region::IE,
         Region::IT,
-        Region::ES,
+        Region::LV,
+        Region::LT,
+        Region::NL,
+        Region::NO,
         Region::PL,
+        Region::PT,
+        Region::RO,
+        Region::SK,
+        Region::ES,
+        Region::SE,
+        Region::CH,
+        Region::GB,
+        // Americas
+        Region::AR,
         Region::BR,
+        Region::CA,
+        Region::CL,
+        Region::CO,
+        Region::MX,
+        Region::US,
+        // Asia-Pacific
+        Region::AU,
+        Region::CN,
+        Region::HK,
+        Region::IN,
+        Region::ID,
+        Region::JP,
+        Region::NZ,
+        Region::PH,
+        Region::SG,
+        Region::KR,
+        Region::TW,
+        Region::TH,
+        // Middle East & Africa
+        Region::AE,
+        Region::IL,
+        Region::SA,
+        Region::ZA,
+        Region::TR,
     ];
 
     pub fn from_code(code: &str) -> Option<Region> {
         match code {
-            "FR" => Some(Region::FR),
+            "AT" => Some(Region::AT),
+            "BE" => Some(Region::BE),
+            "BG" => Some(Region::BG),
+            "CH" => Some(Region::CH),
+            "CZ" => Some(Region::CZ),
             "DE" => Some(Region::DE),
-            "US" => Some(Region::US),
-            "GB" => Some(Region::GB),
-            "CA" => Some(Region::CA),
-            "AU" => Some(Region::AU),
-            "IT" => Some(Region::IT),
+            "DK" => Some(Region::DK),
+            "EE" => Some(Region::EE),
             "ES" => Some(Region::ES),
+            "FI" => Some(Region::FI),
+            "FR" => Some(Region::FR),
+            "GB" => Some(Region::GB),
+            "GR" => Some(Region::GR),
+            "HR" => Some(Region::HR),
+            "HU" => Some(Region::HU),
+            "IE" => Some(Region::IE),
+            "IT" => Some(Region::IT),
+            "LT" => Some(Region::LT),
+            "LV" => Some(Region::LV),
+            "NL" => Some(Region::NL),
+            "NO" => Some(Region::NO),
             "PL" => Some(Region::PL),
+            "PT" => Some(Region::PT),
+            "RO" => Some(Region::RO),
+            "SE" => Some(Region::SE),
+            "SK" => Some(Region::SK),
+            "AR" => Some(Region::AR),
             "BR" => Some(Region::BR),
+            "CA" => Some(Region::CA),
+            "CL" => Some(Region::CL),
+            "CO" => Some(Region::CO),
+            "MX" => Some(Region::MX),
+            "US" => Some(Region::US),
+            "AU" => Some(Region::AU),
+            "CN" => Some(Region::CN),
+            "HK" => Some(Region::HK),
+            "ID" => Some(Region::ID),
+            "IN" => Some(Region::IN),
+            "JP" => Some(Region::JP),
+            "KR" => Some(Region::KR),
+            "NZ" => Some(Region::NZ),
+            "PH" => Some(Region::PH),
+            "SG" => Some(Region::SG),
+            "TH" => Some(Region::TH),
+            "TW" => Some(Region::TW),
+            "AE" => Some(Region::AE),
+            "IL" => Some(Region::IL),
+            "SA" => Some(Region::SA),
+            "TR" => Some(Region::TR),
+            "ZA" => Some(Region::ZA),
             // Handle old config values
             "EU1" => Some(Region::FR),
             "EU2" => Some(Region::PL),


### PR DESCRIPTION
## Description

Extends the region picker from 10 hardcoded countries to 48, covering Europe, Americas, Asia-Pacific, and Middle East & Africa. The ITAD API accepts any ISO 3166-1 alpha-2 country code, so no API changes were needed, prices and currencies are returned automatically based on the selected country.

## Related issues

Closes #5

## Checklist

- [x] Code compiles without warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] I have tested the changes locally
