### PR TITLE
feat: add theme selector with 9 color themes

### DIFF
--- a/tui/src/config.rs
+++ b/tui/src/config.rs
@@ -1,4 +1,5 @@
 use crate::model::{SortCriteria, SortDirection, SortState};
+use crate::view::styles::Theme;
 use dealve_core::models::{Platform, Region};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -27,6 +28,9 @@ pub struct Config {
     /// Default sort direction (Ascending or Descending)
     #[serde(default = "default_sort_direction")]
     pub default_sort_direction: String,
+    /// Color theme
+    #[serde(default = "default_theme")]
+    pub theme: String,
 }
 
 fn default_region() -> String {
@@ -49,6 +53,10 @@ fn default_sort_direction() -> String {
     "Ascending".to_string()
 }
 
+fn default_theme() -> String {
+    "default".to_string()
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -60,6 +68,7 @@ impl Default for Config {
             api_key: None,
             default_sort_criteria: default_sort_criteria(),
             default_sort_direction: default_sort_direction(),
+            theme: default_theme(),
         }
     }
 }
@@ -124,6 +133,11 @@ impl Config {
         Region::from_code(&self.region).unwrap_or_default()
     }
 
+    /// Get the theme from config
+    pub fn get_theme(&self) -> Theme {
+        Theme::from_id(&self.theme).unwrap_or_default()
+    }
+
     /// Update from OptionsState
     pub fn update_from_options(
         &mut self,
@@ -131,6 +145,7 @@ impl Config {
         enabled_platforms: &HashSet<Platform>,
         region: Region,
         default_sort: SortState,
+        theme: Theme,
     ) {
         self.default_platform = default_platform.name().to_string();
         self.enabled_platforms = enabled_platforms
@@ -143,6 +158,7 @@ impl Config {
             SortDirection::Ascending => "Ascending".to_string(),
             SortDirection::Descending => "Descending".to_string(),
         };
+        self.theme = theme.id().to_string();
     }
 
     /// Get the default sort state from config

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -12,7 +12,7 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     ExecutableCommand,
 };
-use ratatui::{backend::CrosstermBackend, layout::Rect, prelude::Color, Terminal};
+use ratatui::{backend::CrosstermBackend, layout::Rect, Terminal};
 use std::io::{stdout, Stdout};
 use tachyonfx::fx::EvolveSymbolSet;
 use tachyonfx::pattern::RadialPattern;
@@ -75,9 +75,8 @@ async fn run(
     let term_size = terminal.size()?;
     let full_screen = Rect::new(0, 0, term_size.width, term_size.height);
 
-    let style = ratatui::style::Style::default()
-        .fg(Color::Rgb(20, 15, 30))
-        .bg(Color::Rgb(10, 8, 15));
+    let bg = view::styles::bg_dark();
+    let style = ratatui::style::Style::default().fg(bg).bg(bg);
 
     let timer = EffectTimer::from_ms(1200, Interpolation::CubicOut);
     effects.push((
@@ -87,7 +86,7 @@ async fn run(
     ));
 
     loop {
-        // ── 1. View ─────────────────────────────────────────────────────
+        // View
         let elapsed = last_frame_time.elapsed();
         last_frame_time = std::time::Instant::now();
 
@@ -105,14 +104,14 @@ async fn run(
             break;
         }
 
-        // ── 2. Check async tasks ────────────────────────────────────────
+        // Check async tasks
         let task_messages = tasks::check_tasks(&mut model, &mut task_mgr).await;
         for msg in task_messages {
             let result = update::update(&mut model, msg);
             handle_result(&mut model, &mut task_mgr, &mut effects, terminal, result)?;
         }
 
-        // ── 3. Game info loading (debounced) ────────────────────────────
+        // Game info loading (debounced)
         if task_mgr.pending_game_info_load
             && !model.loading.deals
             && effects.is_empty()
@@ -123,7 +122,7 @@ async fn run(
             tasks::load_game_info_if_needed(&mut model).await;
         }
 
-        // ── 4. Handle event ─────────────────────────────────────────────
+        // Handle event
         let poll_duration = if !effects.is_empty() {
             std::time::Duration::from_millis(16)
         } else {
@@ -169,7 +168,7 @@ fn handle_result(
                 Motion::UpToDown,
                 15,
                 3,
-                Color::Rgb(20, 15, 30),
+                view::styles::bg_dark(),
                 (600, Interpolation::QuadOut),
             ),
             deals_inner,

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -76,7 +76,9 @@ async fn run(
     let full_screen = Rect::new(0, 0, term_size.width, term_size.height);
 
     let bg = view::styles::bg_dark();
-    let style = ratatui::style::Style::default().fg(bg).bg(bg);
+    let style = ratatui::style::Style::default()
+        .fg(bg)
+        .bg(ratatui::prelude::Color::Black);
 
     let timer = EffectTimer::from_ms(1200, Interpolation::CubicOut);
     effects.push((

--- a/tui/src/model.rs
+++ b/tui/src/model.rs
@@ -3,9 +3,9 @@ use ratatui::widgets::{ListState, TableState};
 use std::collections::{HashMap, HashSet};
 
 use crate::config::Config;
+use crate::view::styles::Theme;
 
-// ── Enums ───────────────────────────────────────────────────────────────────
-
+// Enums
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MenuItem {
     Browse,
@@ -151,6 +151,7 @@ pub enum OptionsTab {
     Region,
     Platforms,
     Advanced,
+    Theme,
 }
 
 impl OptionsTab {
@@ -158,6 +159,7 @@ impl OptionsTab {
         OptionsTab::Region,
         OptionsTab::Platforms,
         OptionsTab::Advanced,
+        OptionsTab::Theme,
     ];
 
     pub fn name(&self) -> &str {
@@ -165,12 +167,12 @@ impl OptionsTab {
             OptionsTab::Region => "Region",
             OptionsTab::Platforms => "Platforms",
             OptionsTab::Advanced => "Advanced",
+            OptionsTab::Theme => "Theme",
         }
     }
 }
 
-// ── Sub-states ──────────────────────────────────────────────────────────────
-
+// Sub-states
 #[derive(Debug, Clone, Default)]
 pub struct PriceFilterState {
     pub min_input: String,
@@ -226,12 +228,14 @@ pub struct OptionsState {
     pub platform_list_index: usize,
     pub region_list_index: usize,
     pub advanced_list_index: usize,
+    pub theme_list_index: usize,
     pub default_platform: Platform,
     pub enabled_platforms: HashSet<Platform>,
     pub region: Region,
     pub deals_page_size: usize,
     pub game_info_delay_ms: u64,
     pub default_sort: SortState,
+    pub theme: Theme,
 }
 
 impl Default for OptionsState {
@@ -245,12 +249,14 @@ impl Default for OptionsState {
             platform_list_index: 0,
             region_list_index: 0,
             advanced_list_index: 0,
+            theme_list_index: 0,
             default_platform: Platform::All,
             enabled_platforms: enabled,
             region: Region::default(),
             deals_page_size: 50,
             game_info_delay_ms: 200,
             default_sort: SortState::default(),
+            theme: Theme::default(),
         }
     }
 }
@@ -261,6 +267,7 @@ impl OptionsState {
         let default_platform = config.get_default_platform();
         let region = config.get_region();
         let default_sort = config.get_default_sort();
+        let theme = config.get_theme();
 
         let default_platform = if enabled_platforms.contains(&default_platform) {
             default_platform
@@ -273,12 +280,14 @@ impl OptionsState {
             platform_list_index: 0,
             region_list_index: 0,
             advanced_list_index: 0,
+            theme_list_index: 0,
             default_platform,
             enabled_platforms,
             region,
             deals_page_size: config.deals_page_size,
             game_info_delay_ms: config.game_info_delay_ms,
             default_sort,
+            theme,
         }
     }
 
@@ -289,6 +298,7 @@ impl OptionsState {
             &self.enabled_platforms,
             self.region,
             self.default_sort,
+            self.theme,
         );
         config.deals_page_size = self.deals_page_size;
         config.game_info_delay_ms = self.game_info_delay_ms;
@@ -353,8 +363,7 @@ impl Default for UiState {
     }
 }
 
-// ── Model ───────────────────────────────────────────────────────────────────
-
+// Model
 pub struct Model {
     // Data
     pub deals: Vec<Deal>,
@@ -404,6 +413,7 @@ impl Model {
         let platform_filter = options.default_platform;
         let region = options.region;
         let sort_state = options.default_sort;
+        crate::view::styles::set_active_theme(options.theme);
 
         Self {
             deals: vec![],
@@ -446,8 +456,7 @@ impl Model {
         self.select(Some(0));
     }
 
-    // ── Query methods ───────────────────────────────────────────────────
-
+    // Query methods
     pub fn filtered_deals(&self) -> Vec<&Deal> {
         let mut deals: Vec<&Deal> = match self.platform_filter.shop_id() {
             None => self.deals.iter().collect(),

--- a/tui/src/onboarding.rs
+++ b/tui/src/onboarding.rs
@@ -597,7 +597,7 @@ pub async fn run_onboarding(
 
     let style = ratatui::style::Style::default()
         .fg(bg_dark())
-        .bg(Color::Rgb(10, 8, 15));
+        .bg(Color::Black);
 
     let timer = EffectTimer::from_ms(1000, Interpolation::CubicOut);
     effects.push((

--- a/tui/src/onboarding.rs
+++ b/tui/src/onboarding.rs
@@ -16,8 +16,8 @@ use tachyonfx::{fx, Effect, EffectTimer, Interpolation, Motion};
 
 use crate::config::Config;
 use crate::view::styles::{
-    ACCENT_GREEN, ASCII_LOGO, BG_DARK, ERROR_RED, PURPLE_ACCENT, PURPLE_LIGHT, PURPLE_PRIMARY,
-    SHORTCUT_KEY, TEXT_PRIMARY, TEXT_SECONDARY,
+    accent, bg_dark, error_red, green, primary, primary_light, shortcut_key, text_primary,
+    text_secondary, ASCII_LOGO,
 };
 
 const SPINNER_FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -85,7 +85,7 @@ pub fn render(frame: &mut Frame, state: &OnboardingState) {
     let area = frame.area();
 
     // Clear background
-    let bg = Block::default().style(Style::default().bg(BG_DARK));
+    let bg = Block::default().style(Style::default().bg(bg_dark()));
     frame.render_widget(bg, area);
 
     match &state.step {
@@ -120,21 +120,21 @@ fn render_welcome(frame: &mut Frame, area: Rect) {
     // Logo
     let logo_text: Vec<Line> = ASCII_LOGO
         .iter()
-        .map(|line| Line::from(Span::styled(*line, Style::default().fg(PURPLE_PRIMARY))))
+        .map(|line| Line::from(Span::styled(*line, Style::default().fg(primary()))))
         .collect();
     let logo = Paragraph::new(logo_text).alignment(Alignment::Center);
     frame.render_widget(logo, chunks[1]);
 
     // Title
     let title = Paragraph::new(Line::from(vec![
-        Span::styled("Welcome to ", Style::default().fg(TEXT_SECONDARY)),
+        Span::styled("Welcome to ", Style::default().fg(text_secondary())),
         Span::styled(
             "Dealve",
             Style::default()
-                .fg(PURPLE_LIGHT)
+                .fg(primary_light())
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled(" - Game Deal Finder", Style::default().fg(TEXT_SECONDARY)),
+        Span::styled(" - Game Deal Finder", Style::default().fg(text_secondary())),
     ]))
     .alignment(Alignment::Center);
     frame.render_widget(title, chunks[3]);
@@ -143,11 +143,11 @@ fn render_welcome(frame: &mut Frame, area: Rect) {
     let subtitle = Paragraph::new(vec![
         Line::from(Span::styled(
             "Browse the best game deals from IsThereAnyDeal.com",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         )),
         Line::from(Span::styled(
             "across Steam, GOG, Humble, Epic, and more stores.",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         )),
     ])
     .alignment(Alignment::Center);
@@ -160,16 +160,16 @@ fn render_welcome(frame: &mut Frame, area: Rect) {
 
     let info_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PURPLE_ACCENT));
+        .border_style(Style::default().fg(accent()));
 
     let info_text = Paragraph::new(vec![
         Line::from(Span::styled(
             "To get started, you'll need an IsThereAnyDeal",
-            Style::default().fg(TEXT_PRIMARY),
+            Style::default().fg(text_primary()),
         )),
         Line::from(Span::styled(
             "API key. Don't worry - it's free!",
-            Style::default().fg(TEXT_PRIMARY),
+            Style::default().fg(text_primary()),
         )),
     ])
     .alignment(Alignment::Center)
@@ -196,14 +196,14 @@ fn render_instructions(frame: &mut Frame, area: Rect) {
 
     // Title with btop-style brackets
     let title = Paragraph::new(Line::from(vec![
-        Span::styled("┐", Style::default().fg(PURPLE_ACCENT)),
+        Span::styled("┐", Style::default().fg(accent())),
         Span::styled(
             "Getting Your API Key",
             Style::default()
-                .fg(PURPLE_LIGHT)
+                .fg(primary_light())
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled("┌", Style::default().fg(PURPLE_ACCENT)),
+        Span::styled("┌", Style::default().fg(accent())),
     ]))
     .alignment(Alignment::Center);
     frame.render_widget(title, chunks[1]);
@@ -215,12 +215,10 @@ fn render_instructions(frame: &mut Frame, area: Rect) {
 
     let instructions_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PURPLE_ACCENT));
+        .border_style(Style::default().fg(accent()));
 
-    let step_style = Style::default()
-        .fg(PURPLE_PRIMARY)
-        .add_modifier(Modifier::BOLD);
-    let text_style = Style::default().fg(TEXT_PRIMARY);
+    let step_style = Style::default().fg(primary()).add_modifier(Modifier::BOLD);
+    let text_style = Style::default().fg(text_primary());
 
     let instructions = Paragraph::new(vec![
         Line::from(""),
@@ -230,7 +228,7 @@ fn render_instructions(frame: &mut Frame, area: Rect) {
             Span::styled(
                 "isthereanydeal.com",
                 Style::default()
-                    .fg(PURPLE_LIGHT)
+                    .fg(primary_light())
                     .add_modifier(Modifier::UNDERLINED),
             ),
         ]),
@@ -256,11 +254,11 @@ fn render_instructions(frame: &mut Frame, area: Rect) {
 
     // Tip
     let tip = Paragraph::new(Line::from(vec![
-        Span::styled("Tip: Press ", Style::default().fg(TEXT_SECONDARY)),
-        Span::styled("[o]", Style::default().fg(SHORTCUT_KEY)),
+        Span::styled("Tip: Press ", Style::default().fg(text_secondary())),
+        Span::styled("[o]", Style::default().fg(shortcut_key())),
         Span::styled(
             " to open the website in your browser",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         ),
     ]))
     .alignment(Alignment::Center);
@@ -291,14 +289,14 @@ fn render_api_key_entry(frame: &mut Frame, state: &OnboardingState, area: Rect) 
 
     // Title
     let title = Paragraph::new(Line::from(vec![
-        Span::styled("┐", Style::default().fg(PURPLE_ACCENT)),
+        Span::styled("┐", Style::default().fg(accent())),
         Span::styled(
             "Enter Your API Key",
             Style::default()
-                .fg(PURPLE_LIGHT)
+                .fg(primary_light())
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled("┌", Style::default().fg(PURPLE_ACCENT)),
+        Span::styled("┌", Style::default().fg(accent())),
     ]))
     .alignment(Alignment::Center);
     frame.render_widget(title, chunks[1]);
@@ -310,7 +308,7 @@ fn render_api_key_entry(frame: &mut Frame, state: &OnboardingState, area: Rect) 
 
     let input_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PURPLE_ACCENT));
+        .border_style(Style::default().fg(accent()));
 
     // Build input field content
     let displayed = state.displayed_key();
@@ -320,31 +318,31 @@ fn render_api_key_entry(frame: &mut Frame, state: &OnboardingState, area: Rect) 
         Line::from(""),
         Line::from(Span::styled(
             "Paste your IsThereAnyDeal API key below:",
-            Style::default().fg(TEXT_PRIMARY),
+            Style::default().fg(text_primary()),
         )),
         Line::from(""),
         Line::from(vec![
-            Span::styled("┌", Style::default().fg(TEXT_SECONDARY)),
-            Span::styled("─".repeat(46), Style::default().fg(TEXT_SECONDARY)),
-            Span::styled("┐", Style::default().fg(TEXT_SECONDARY)),
+            Span::styled("┌", Style::default().fg(text_secondary())),
+            Span::styled("─".repeat(46), Style::default().fg(text_secondary())),
+            Span::styled("┐", Style::default().fg(text_secondary())),
         ]),
         Line::from(vec![
-            Span::styled("│ ", Style::default().fg(TEXT_SECONDARY)),
+            Span::styled("│ ", Style::default().fg(text_secondary())),
             Span::styled(
                 format!("{:<44}", format!("{}{}", displayed, cursor)),
-                Style::default().fg(PURPLE_LIGHT),
+                Style::default().fg(primary_light()),
             ),
-            Span::styled(" │", Style::default().fg(TEXT_SECONDARY)),
+            Span::styled(" │", Style::default().fg(text_secondary())),
         ]),
         Line::from(vec![
-            Span::styled("└", Style::default().fg(TEXT_SECONDARY)),
-            Span::styled("─".repeat(46), Style::default().fg(TEXT_SECONDARY)),
-            Span::styled("┘", Style::default().fg(TEXT_SECONDARY)),
+            Span::styled("└", Style::default().fg(text_secondary())),
+            Span::styled("─".repeat(46), Style::default().fg(text_secondary())),
+            Span::styled("┘", Style::default().fg(text_secondary())),
         ]),
         Line::from(""),
         Line::from(Span::styled(
             "Tip: Use Ctrl+V or Ctrl+Shift+V to paste",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         )),
     ])
     .alignment(Alignment::Center)
@@ -377,14 +375,14 @@ fn render_validating(frame: &mut Frame, state: &OnboardingState, area: Rect) {
 
     // Title
     let title = Paragraph::new(Line::from(vec![
-        Span::styled("┐", Style::default().fg(PURPLE_ACCENT)),
+        Span::styled("┐", Style::default().fg(accent())),
         Span::styled(
             "Validating...",
             Style::default()
-                .fg(PURPLE_LIGHT)
+                .fg(primary_light())
                 .add_modifier(Modifier::BOLD),
         ),
-        Span::styled("┌", Style::default().fg(PURPLE_ACCENT)),
+        Span::styled("┌", Style::default().fg(accent())),
     ]))
     .alignment(Alignment::Center);
     frame.render_widget(title, chunks[1]);
@@ -393,11 +391,11 @@ fn render_validating(frame: &mut Frame, state: &OnboardingState, area: Rect) {
     let spinner = Paragraph::new(Line::from(vec![
         Span::styled(
             format!("{} ", state.spinner_char()),
-            Style::default().fg(PURPLE_PRIMARY),
+            Style::default().fg(primary()),
         ),
         Span::styled(
             "Connecting to IsThereAnyDeal...",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         ),
     ]))
     .alignment(Alignment::Center);
@@ -418,14 +416,12 @@ fn render_success(frame: &mut Frame, area: Rect) {
 
     // Title
     let title = Paragraph::new(Line::from(vec![
-        Span::styled("┐", Style::default().fg(ACCENT_GREEN)),
+        Span::styled("┐", Style::default().fg(green())),
         Span::styled(
             "Setup Complete!",
-            Style::default()
-                .fg(ACCENT_GREEN)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(green()).add_modifier(Modifier::BOLD),
         ),
-        Span::styled("┌", Style::default().fg(ACCENT_GREEN)),
+        Span::styled("┌", Style::default().fg(green())),
     ]))
     .alignment(Alignment::Center);
     frame.render_widget(title, chunks[1]);
@@ -437,20 +433,18 @@ fn render_success(frame: &mut Frame, area: Rect) {
 
     let success_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(ACCENT_GREEN));
+        .border_style(Style::default().fg(green()));
 
     let success_text = Paragraph::new(vec![
         Line::from(""),
         Line::from(Span::styled(
             "✓ API Key Valid!",
-            Style::default()
-                .fg(ACCENT_GREEN)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(green()).add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(
             "Your key has been saved. You're all set!",
-            Style::default().fg(TEXT_PRIMARY),
+            Style::default().fg(text_primary()),
         )),
     ])
     .alignment(Alignment::Center)
@@ -474,12 +468,14 @@ fn render_failed(frame: &mut Frame, area: Rect, error: &str) {
 
     // Title
     let title = Paragraph::new(Line::from(vec![
-        Span::styled("┐", Style::default().fg(ERROR_RED)),
+        Span::styled("┐", Style::default().fg(error_red())),
         Span::styled(
             "Validation Failed",
-            Style::default().fg(ERROR_RED).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(error_red())
+                .add_modifier(Modifier::BOLD),
         ),
-        Span::styled("┌", Style::default().fg(ERROR_RED)),
+        Span::styled("┌", Style::default().fg(error_red())),
     ]))
     .alignment(Alignment::Center);
     frame.render_widget(title, chunks[1]);
@@ -491,20 +487,22 @@ fn render_failed(frame: &mut Frame, area: Rect, error: &str) {
 
     let error_block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(ERROR_RED));
+        .border_style(Style::default().fg(error_red()));
 
     let error_text = Paragraph::new(vec![
         Line::from(""),
         Line::from(Span::styled(
             "✗ Invalid API Key",
-            Style::default().fg(ERROR_RED).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(error_red())
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
-        Line::from(Span::styled(error, Style::default().fg(TEXT_SECONDARY))),
+        Line::from(Span::styled(error, Style::default().fg(text_secondary()))),
         Line::from(""),
         Line::from(Span::styled(
             "Please check your key and try again.",
-            Style::default().fg(TEXT_PRIMARY),
+            Style::default().fg(text_primary()),
         )),
     ])
     .alignment(Alignment::Center)
@@ -521,7 +519,7 @@ fn render_failed(frame: &mut Frame, area: Rect, error: &str) {
 fn render_progress_dots(frame: &mut Frame, state: &OnboardingState, area: Rect) {
     let dots = state.progress_dots();
     let dot_line = Line::from(vec![
-        Span::styled("[Step ", Style::default().fg(TEXT_SECONDARY)),
+        Span::styled("[Step ", Style::default().fg(text_secondary())),
         Span::styled(
             match state.step {
                 OnboardingStep::Welcome => "1",
@@ -529,43 +527,27 @@ fn render_progress_dots(frame: &mut Frame, state: &OnboardingState, area: Rect) 
                 OnboardingStep::ApiKeyEntry => "3",
                 _ => "4",
             },
-            Style::default().fg(PURPLE_LIGHT),
+            Style::default().fg(primary_light()),
         ),
-        Span::styled(" of 4] ", Style::default().fg(TEXT_SECONDARY)),
+        Span::styled(" of 4] ", Style::default().fg(text_secondary())),
         Span::styled(
             if dots[0] { "●" } else { "○" },
-            Style::default().fg(if dots[0] {
-                PURPLE_PRIMARY
-            } else {
-                TEXT_SECONDARY
-            }),
+            Style::default().fg(if dots[0] { primary() } else { text_secondary() }),
         ),
         Span::styled(" ", Style::default()),
         Span::styled(
             if dots[1] { "●" } else { "○" },
-            Style::default().fg(if dots[1] {
-                PURPLE_PRIMARY
-            } else {
-                TEXT_SECONDARY
-            }),
+            Style::default().fg(if dots[1] { primary() } else { text_secondary() }),
         ),
         Span::styled(" ", Style::default()),
         Span::styled(
             if dots[2] { "●" } else { "○" },
-            Style::default().fg(if dots[2] {
-                PURPLE_PRIMARY
-            } else {
-                TEXT_SECONDARY
-            }),
+            Style::default().fg(if dots[2] { primary() } else { text_secondary() }),
         ),
         Span::styled(" ", Style::default()),
         Span::styled(
             if dots[3] { "●" } else { "○" },
-            Style::default().fg(if dots[3] {
-                PURPLE_PRIMARY
-            } else {
-                TEXT_SECONDARY
-            }),
+            Style::default().fg(if dots[3] { primary() } else { text_secondary() }),
         ),
     ]);
 
@@ -581,8 +563,11 @@ fn render_action_hints(frame: &mut Frame, area: Rect, hints: &[(&str, &str)]) {
         .enumerate()
         .flat_map(|(i, (key, action))| {
             let mut s = vec![
-                Span::styled(format!("[{}]", key), Style::default().fg(SHORTCUT_KEY)),
-                Span::styled(format!(" {}", action), Style::default().fg(TEXT_SECONDARY)),
+                Span::styled(format!("[{}]", key), Style::default().fg(shortcut_key())),
+                Span::styled(
+                    format!(" {}", action),
+                    Style::default().fg(text_secondary()),
+                ),
             ];
             if i < hints.len() - 1 {
                 s.push(Span::styled("  ", Style::default()));
@@ -611,7 +596,7 @@ pub async fn run_onboarding(
     let full_screen = Rect::new(0, 0, term_size.width, term_size.height);
 
     let style = ratatui::style::Style::default()
-        .fg(BG_DARK)
+        .fg(bg_dark())
         .bg(Color::Rgb(10, 8, 15));
 
     let timer = EffectTimer::from_ms(1000, Interpolation::CubicOut);
@@ -665,7 +650,7 @@ pub async fn run_onboarding(
                                     Motion::UpToDown,
                                     10,
                                     2,
-                                    BG_DARK,
+                                    bg_dark(),
                                     (400, Interpolation::QuadOut),
                                 ),
                                 Rect::new(0, 0, term_size.width, term_size.height),
@@ -778,7 +763,7 @@ fn add_transition_effect(
             Motion::LeftToRight,
             8,
             2,
-            BG_DARK,
+            bg_dark(),
             (250, Interpolation::QuadOut),
         ),
         Rect::new(0, 0, term_size.width, term_size.height),

--- a/tui/src/update.rs
+++ b/tui/src/update.rs
@@ -49,7 +49,7 @@ impl UpdateResult {
 
 pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
     match msg {
-        // ── Navigation ──────────────────────────────────────────────────
+        // Navigation
         Message::SelectNext => {
             let filtered_count = model.filtered_deals().len();
             if filtered_count > 0 {
@@ -130,7 +130,7 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             UpdateResult::none()
         }
 
-        // ── Menu ────────────────────────────────────────────────────────
+        // Menu
         Message::ToggleMenu => {
             model.ui.show_menu = !model.ui.show_menu;
             if model.ui.show_menu {
@@ -168,7 +168,7 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             UpdateResult::none()
         }
 
-        // ── Filtering ───────────────────────────────────────────────────
+        // Filtering
         Message::StartFilter => {
             model.filter.active = true;
             model.filter.text = model.active_search_query.clone().unwrap_or_default();
@@ -230,7 +230,7 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             UpdateResult::none()
         }
 
-        // ── Price filter ────────────────────────────────────────────────
+        // Price filter
         Message::OpenPriceFilter => {
             model.price_filter.min_input = model
                 .price_filter
@@ -285,7 +285,7 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             UpdateResult::with_selection_changed()
         }
 
-        // ── Platform popup ──────────────────────────────────────────────
+        // Platform popup
         Message::OpenPlatformPopup => {
             let enabled = model.enabled_platforms();
             model.ui.platform_popup_index = enabled
@@ -329,7 +329,7 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             UpdateResult::none()
         }
 
-        // ── Sort ────────────────────────────────────────────────────────
+        // Sort
         Message::ToggleSortDirection => {
             model.sort_state.direction = model.sort_state.direction.toggle();
             model.select(Some(0));
@@ -366,21 +366,23 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             }
         }
 
-        // ── Popups ──────────────────────────────────────────────────────
+        // Popups
         Message::ClosePopup => {
             model.ui.popup = Popup::None;
             model.options.platform_list_index = 0;
             model.options.region_list_index = 0;
             model.options.advanced_list_index = 0;
+            model.options.theme_list_index = 0;
             UpdateResult::none()
         }
 
-        // ── Options ─────────────────────────────────────────────────────
+        // Options
         Message::OptionsNextTab => {
             model.options.current_tab = (model.options.current_tab + 1) % OptionsTab::ALL.len();
             model.options.platform_list_index = 0;
             model.options.region_list_index = 0;
             model.options.advanced_list_index = 0;
+            model.options.theme_list_index = 0;
             UpdateResult::none()
         }
         Message::OptionsPrevTab => {
@@ -392,6 +394,7 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             model.options.platform_list_index = 0;
             model.options.region_list_index = 0;
             model.options.advanced_list_index = 0;
+            model.options.theme_list_index = 0;
             UpdateResult::none()
         }
         Message::OptionsNextItem => {
@@ -407,6 +410,10 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
                 }
                 OptionsTab::Advanced => {
                     model.options.advanced_list_index = (model.options.advanced_list_index + 1) % 3;
+                }
+                OptionsTab::Theme => {
+                    model.options.theme_list_index = (model.options.theme_list_index + 1)
+                        % crate::view::styles::Theme::ALL.len();
                 }
             }
             UpdateResult::none()
@@ -434,6 +441,13 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
                         model.options.advanced_list_index = 2;
                     } else {
                         model.options.advanced_list_index -= 1;
+                    }
+                }
+                OptionsTab::Theme => {
+                    if model.options.theme_list_index == 0 {
+                        model.options.theme_list_index = crate::view::styles::Theme::ALL.len() - 1;
+                    } else {
+                        model.options.theme_list_index -= 1;
                     }
                 }
             }
@@ -499,6 +513,15 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
                     }
                     model.options.save_to_config();
                 }
+                OptionsTab::Theme => {
+                    if let Some(&theme) =
+                        crate::view::styles::Theme::ALL.get(model.options.theme_list_index)
+                    {
+                        model.options.theme = theme;
+                        crate::view::styles::set_active_theme(theme);
+                    }
+                    model.options.save_to_config();
+                }
             }
             if needs_reload {
                 model.ui.popup = Popup::None;
@@ -518,7 +541,7 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             UpdateResult::none()
         }
 
-        // ── Data loading results ────────────────────────────────────────
+        // Data loading results
         Message::DealsLoaded {
             deals,
             is_more,
@@ -562,7 +585,7 @@ pub fn update(model: &mut Model, msg: Message) -> UpdateResult {
             UpdateResult::none()
         }
 
-        // ── System ──────────────────────────────────────────────────────
+        // System
         Message::RequestRefresh => UpdateResult::with_reload(),
 
         Message::Tick => {

--- a/tui/src/view/deals_list.rs
+++ b/tui/src/view/deals_list.rs
@@ -13,9 +13,17 @@ use super::styles::*;
 use crate::model::Model;
 
 pub fn render_deals_list(frame: &mut Frame, model: &mut Model, area: Rect, dimmed: bool) {
-    let text_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
-    let border_color = if dimmed { TEXT_DIMMED } else { PURPLE_ACCENT };
-    let title_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
+    let text_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
+    let border_color = if dimmed { text_dimmed() } else { accent() };
+    let title_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
 
     let title_text = format!("Deals [{}]", model.platform_filter.name());
     let title = build_title(&title_text, border_color, title_color);
@@ -42,7 +50,7 @@ pub fn render_deals_list(frame: &mut Frame, model: &mut Model, area: Rect, dimme
     if let Some(error) = &model.error {
         let error_title = build_title("Error", border_color, title_color);
         let error_msg = Paragraph::new(format!("Error: {}", error))
-            .style(Style::default().fg(ratatui::style::Color::Red))
+            .style(Style::default().fg(error_red()))
             .block(
                 Block::default()
                     .borders(Borders::ALL)
@@ -73,7 +81,11 @@ pub fn render_deals_list(frame: &mut Frame, model: &mut Model, area: Rect, dimme
     }
 
     // Build table header
-    let header_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
+    let header_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
     let header = Row::new(vec![
         Cell::from("Title").style(Style::default().fg(header_color)),
         Cell::from("Price").style(Style::default().fg(header_color)),
@@ -94,19 +106,19 @@ pub fn render_deals_list(frame: &mut Frame, model: &mut Model, area: Rect, dimme
                 .unwrap_or(false);
 
             let (item_title_color, price_color, discount_color) = if dimmed {
-                (TEXT_DIMMED, TEXT_DIMMED, TEXT_DIMMED)
+                (text_dimmed(), text_dimmed(), text_dimmed())
             } else if is_atl {
-                (TEXT_SECONDARY, PURPLE_PRIMARY, PURPLE_PRIMARY)
+                (text_secondary(), primary(), primary())
             } else if deal.price.discount >= 75 {
-                (TEXT_SECONDARY, ACCENT_GREEN, ACCENT_GREEN)
+                (text_secondary(), green(), green())
             } else if deal.price.discount >= 50 {
-                (TEXT_SECONDARY, ACCENT_YELLOW, ACCENT_YELLOW)
+                (text_secondary(), yellow(), yellow())
             } else {
-                (TEXT_SECONDARY, TEXT_SECONDARY, TEXT_SECONDARY)
+                (text_secondary(), text_secondary(), text_secondary())
             };
 
             let atl_cell = if is_atl {
-                let atl_color = if dimmed { TEXT_DIMMED } else { PURPLE_PRIMARY };
+                let atl_color = if dimmed { text_dimmed() } else { primary() };
                 Cell::from("ATL").style(Style::default().fg(atl_color).add_modifier(Modifier::BOLD))
             } else {
                 Cell::from("")
@@ -122,9 +134,9 @@ pub fn render_deals_list(frame: &mut Frame, model: &mut Model, area: Rect, dimme
         .collect();
 
     let highlight_style = if dimmed {
-        Style::default().fg(TEXT_DIMMED)
+        Style::default().fg(text_dimmed())
     } else {
-        Style::default().bg(BG_HIGHLIGHT)
+        Style::default().bg(bg_highlight())
     };
 
     let total_items = filtered_deals.len();
@@ -132,7 +144,11 @@ pub fn render_deals_list(frame: &mut Frame, model: &mut Model, area: Rect, dimme
 
     // Counter for bottom right corner
     // Use spinner in place of "+" to avoid width changes during loading
-    let counter_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
+    let counter_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
     let suffix = if model.pagination.loading_more {
         format!("{}", model.spinner_char())
     } else if model.pagination.has_more {
@@ -170,8 +186,12 @@ pub fn render_deals_list(frame: &mut Frame, model: &mut Model, area: Rect, dimme
     frame.render_stateful_widget(table, area, &mut model.ui.table_state);
 
     // Render scrollbar
-    let scrollbar_track_color = if dimmed { TEXT_DIMMED } else { PURPLE_ACCENT };
-    let scrollbar_arrow_color = if dimmed { TEXT_DIMMED } else { SHORTCUT_KEY };
+    let scrollbar_track_color = if dimmed { text_dimmed() } else { accent() };
+    let scrollbar_arrow_color = if dimmed {
+        text_dimmed()
+    } else {
+        shortcut_key()
+    };
 
     let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
         .begin_symbol(Some("↑"))
@@ -195,10 +215,22 @@ pub fn render_deals_list(frame: &mut Frame, model: &mut Model, area: Rect, dimme
 
 /// Build status bar line with btop-style highlighted shortcut keys and separators
 fn build_status_line(model: &Model, dimmed: bool) -> Line<'static> {
-    let text_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
-    let shortcut_color = if dimmed { TEXT_DIMMED } else { SHORTCUT_KEY };
-    let value_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
-    let border_color = if dimmed { TEXT_DIMMED } else { PURPLE_ACCENT };
+    let text_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
+    let sc_color = if dimmed {
+        text_dimmed()
+    } else {
+        shortcut_key()
+    };
+    let value_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
+    let border_color = if dimmed { text_dimmed() } else { accent() };
 
     let mut spans: Vec<Span> = Vec::new();
 
@@ -206,36 +238,36 @@ fn build_status_line(model: &Model, dimmed: bool) -> Line<'static> {
 
     // Filter
     if model.filter.active {
-        spans.push(Span::styled("f ", Style::default().fg(shortcut_color)));
+        spans.push(Span::styled("f ", Style::default().fg(sc_color)));
         spans.push(Span::styled(
             model.filter.text.clone(),
             Style::default().fg(text_color),
         ));
         spans.push(Span::styled("_", Style::default().fg(text_color)));
-        spans.push(Span::styled(" ⏎", Style::default().fg(shortcut_color)));
+        spans.push(Span::styled(" ⏎", Style::default().fg(sc_color)));
     } else if let Some(query) = &model.active_search_query {
-        spans.push(Span::styled("f", Style::default().fg(shortcut_color)));
+        spans.push(Span::styled("f", Style::default().fg(sc_color)));
         spans.push(Span::styled(
             format!("[{}] ", query),
             Style::default().fg(value_color),
         ));
-        spans.push(Span::styled("c", Style::default().fg(shortcut_color)));
+        spans.push(Span::styled("c", Style::default().fg(sc_color)));
         spans.push(Span::styled("lear", Style::default().fg(text_color)));
     } else {
-        spans.push(Span::styled("f", Style::default().fg(shortcut_color)));
+        spans.push(Span::styled("f", Style::default().fg(sc_color)));
         spans.push(Span::styled("ilter", Style::default().fg(text_color)));
     }
 
     spans.push(Span::styled("└┘", Style::default().fg(border_color)));
 
     // Platform
-    spans.push(Span::styled("p", Style::default().fg(shortcut_color)));
+    spans.push(Span::styled("p", Style::default().fg(sc_color)));
     spans.push(Span::styled("latform", Style::default().fg(text_color)));
 
     spans.push(Span::styled("└┘", Style::default().fg(border_color)));
 
     // Price filter
-    spans.push(Span::styled("$", Style::default().fg(shortcut_color)));
+    spans.push(Span::styled("$", Style::default().fg(sc_color)));
     if model.price_filter.is_active() {
         spans.push(Span::styled(
             format!("[{}]", model.price_filter.label()),
@@ -246,9 +278,9 @@ fn build_status_line(model: &Model, dimmed: bool) -> Line<'static> {
     spans.push(Span::styled("└┘", Style::default().fg(border_color)));
 
     // Sort
-    spans.push(Span::styled("s", Style::default().fg(shortcut_color)));
+    spans.push(Span::styled("s", Style::default().fg(sc_color)));
     spans.push(Span::styled("ort[", Style::default().fg(text_color)));
-    spans.push(Span::styled("←", Style::default().fg(shortcut_color)));
+    spans.push(Span::styled("←", Style::default().fg(sc_color)));
     spans.push(Span::styled(
         model.sort_state.criteria.name().to_string(),
         Style::default().fg(value_color),
@@ -257,13 +289,13 @@ fn build_status_line(model: &Model, dimmed: bool) -> Line<'static> {
         model.sort_state.direction.arrow().to_string(),
         Style::default().fg(value_color),
     ));
-    spans.push(Span::styled("→", Style::default().fg(shortcut_color)));
+    spans.push(Span::styled("→", Style::default().fg(sc_color)));
     spans.push(Span::styled("]", Style::default().fg(text_color)));
 
     spans.push(Span::styled("└┘", Style::default().fg(border_color)));
 
     // Refresh
-    spans.push(Span::styled("r", Style::default().fg(shortcut_color)));
+    spans.push(Span::styled("r", Style::default().fg(sc_color)));
     spans.push(Span::styled("efresh", Style::default().fg(text_color)));
 
     spans.push(Span::styled("└", Style::default().fg(border_color)));

--- a/tui/src/view/game_details.rs
+++ b/tui/src/view/game_details.rs
@@ -10,14 +10,30 @@ use super::styles::*;
 use crate::model::Model;
 
 pub fn render_game_details(frame: &mut Frame, model: &Model, area: Rect, dimmed: bool) {
-    let text_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
-    let label_color = if dimmed { TEXT_DIMMED } else { PURPLE_LIGHT };
-    let border_color = if dimmed { TEXT_DIMMED } else { PURPLE_ACCENT };
-    let title_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
-    let purple_color = if dimmed { TEXT_DIMMED } else { PURPLE_PRIMARY };
-    let green_color = if dimmed { TEXT_DIMMED } else { ACCENT_GREEN };
-    let yellow_color = if dimmed { TEXT_DIMMED } else { ACCENT_YELLOW };
-    let secondary_color = if dimmed { TEXT_DIMMED } else { TEXT_SECONDARY };
+    let text_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
+    let label_color = if dimmed {
+        text_dimmed()
+    } else {
+        primary_light()
+    };
+    let border_color = if dimmed { text_dimmed() } else { accent() };
+    let title_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
+    let purple_color = if dimmed { text_dimmed() } else { primary() };
+    let green_color = if dimmed { text_dimmed() } else { green() };
+    let yellow_color = if dimmed { text_dimmed() } else { yellow() };
+    let secondary_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_secondary()
+    };
 
     let title = build_title("Game Details", border_color, title_color);
     let block = Block::default()

--- a/tui/src/view/mod.rs
+++ b/tui/src/view/mod.rs
@@ -12,11 +12,11 @@ use ratatui::{
 };
 
 use crate::model::{Model, Popup};
-use styles::BG_DARK;
+use styles::bg_dark;
 
 pub fn view(frame: &mut Frame, model: &mut Model) {
-    // Fill entire screen with dark purple background
-    let bg_block = Block::default().style(Style::default().bg(BG_DARK));
+    // Fill entire screen with theme background
+    let bg_block = Block::default().style(Style::default().bg(bg_dark()));
     frame.render_widget(bg_block, frame.area());
 
     let dimmed = model.ui.show_menu;

--- a/tui/src/view/popups.rs
+++ b/tui/src/view/popups.rs
@@ -28,7 +28,7 @@ pub fn render_menu_overlay(frame: &mut Frame, model: &Model) {
 
     let logo_lines: Vec<Line> = ASCII_LOGO
         .iter()
-        .map(|line| Line::from(Span::styled(*line, Style::default().fg(PURPLE_PRIMARY))))
+        .map(|line| Line::from(Span::styled(*line, Style::default().fg(primary()))))
         .collect();
     let logo = Paragraph::new(logo_lines).alignment(Alignment::Center);
     frame.render_widget(logo, logo_area);
@@ -45,11 +45,11 @@ pub fn render_menu_overlay(frame: &mut Frame, model: &Model) {
         .map(|(i, item)| {
             let style = if i == model.ui.menu_selected {
                 Style::default()
-                    .bg(BG_HIGHLIGHT)
-                    .fg(PURPLE_LIGHT)
+                    .bg(bg_highlight())
+                    .fg(primary_light())
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(TEXT_SECONDARY)
+                Style::default().fg(text_secondary())
             };
             let prefix = if i == model.ui.menu_selected {
                 "> "
@@ -63,7 +63,7 @@ pub fn render_menu_overlay(frame: &mut Frame, model: &Model) {
     let menu = List::new(items).block(
         Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(PURPLE_LIGHT)),
+            .border_style(Style::default().fg(primary_light())),
     );
 
     frame.render_widget(menu, menu_area);
@@ -80,9 +80,12 @@ pub fn render_options_popup(frame: &mut Frame, model: &Model) {
     frame.render_widget(Clear, popup_area);
 
     let block = Block::default()
-        .title(Span::styled(" Options ", Style::default().fg(PURPLE_LIGHT)))
+        .title(Span::styled(
+            " Options ",
+            Style::default().fg(primary_light()),
+        ))
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PURPLE_ACCENT));
+        .border_style(Style::default().fg(accent()));
     frame.render_widget(block, popup_area);
 
     let inner = Rect::new(
@@ -106,14 +109,14 @@ pub fn render_options_popup(frame: &mut Frame, model: &Model) {
                 Span::styled(
                     format!(" {} ", tab.name()),
                     Style::default()
-                        .fg(TEXT_PRIMARY)
-                        .bg(PURPLE_ACCENT)
+                        .fg(text_primary())
+                        .bg(accent())
                         .add_modifier(Modifier::BOLD),
                 )
             } else {
                 Span::styled(
                     format!(" {} ", tab.name()),
-                    Style::default().fg(TEXT_SECONDARY),
+                    Style::default().fg(text_secondary()),
                 )
             }
         })
@@ -128,6 +131,7 @@ pub fn render_options_popup(frame: &mut Frame, model: &Model) {
         OptionsTab::Region => render_region_tab(frame, model, content_area),
         OptionsTab::Platforms => render_platforms_tab(frame, model, content_area),
         OptionsTab::Advanced => render_advanced_tab(frame, model, content_area),
+        OptionsTab::Theme => render_theme_tab(frame, model, content_area),
     }
 }
 
@@ -143,7 +147,7 @@ fn render_region_tab(frame: &mut Frame, model: &Model, area: Rect) {
 
     let desc = Paragraph::new(Line::from(Span::styled(
         "Select your region for local prices:",
-        Style::default().fg(TEXT_SECONDARY),
+        Style::default().fg(text_secondary()),
     )));
     frame.render_widget(desc, chunks[0]);
 
@@ -161,7 +165,7 @@ fn render_region_tab(frame: &mut Frame, model: &Model, area: Rect) {
             region_lines.push(Line::from(Span::styled(
                 format!(" — {} —", current_continent),
                 Style::default()
-                    .fg(PURPLE_LIGHT)
+                    .fg(primary_light())
                     .add_modifier(Modifier::BOLD),
             )));
         }
@@ -175,11 +179,11 @@ fn render_region_tab(frame: &mut Frame, model: &Model, area: Rect) {
 
         let marker = if is_current { "●" } else { "○" };
         let line_style = if is_selected {
-            Style::default().fg(TEXT_PRIMARY).bg(PURPLE_ACCENT)
+            Style::default().fg(text_primary()).bg(accent())
         } else if is_current {
-            Style::default().fg(PURPLE_LIGHT)
+            Style::default().fg(primary_light())
         } else {
-            Style::default().fg(TEXT_PRIMARY)
+            Style::default().fg(text_primary())
         };
 
         region_lines.push(Line::from(Span::styled(
@@ -200,15 +204,18 @@ fn render_region_tab(frame: &mut Frame, model: &Model, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(PURPLE_ACCENT))
-                .title(Span::styled(" Region ", Style::default().fg(PURPLE_LIGHT))),
+                .border_style(Style::default().fg(accent()))
+                .title(Span::styled(
+                    " Region ",
+                    Style::default().fg(primary_light()),
+                )),
         )
         .scroll((scroll_offset, 0));
     frame.render_widget(region_list, chunks[1]);
 
     let help = Paragraph::new(Line::from(Span::styled(
         "[Enter] Select  [Tab] Switch tab  [Esc] Close",
-        Style::default().fg(TEXT_SECONDARY),
+        Style::default().fg(text_secondary()),
     )));
     frame.render_widget(help, chunks[2]);
 }
@@ -226,18 +233,18 @@ fn render_platforms_tab(frame: &mut Frame, model: &Model, area: Rect) {
     // Default platform selector (index 0)
     let is_default_selected = model.options.platform_list_index == 0;
     let default_style = if is_default_selected {
-        Style::default().fg(TEXT_PRIMARY).bg(PURPLE_ACCENT)
+        Style::default().fg(text_primary()).bg(accent())
     } else {
-        Style::default().fg(TEXT_PRIMARY)
+        Style::default().fg(text_primary())
     };
     let default_line = Line::from(vec![
-        Span::styled("Default: ", Style::default().fg(PURPLE_LIGHT)),
+        Span::styled("Default: ", Style::default().fg(primary_light())),
         Span::styled(
             format!("{} ", model.options.default_platform.name()),
             default_style,
         ),
         if is_default_selected {
-            Span::styled("[Enter to change]", Style::default().fg(TEXT_SECONDARY))
+            Span::styled("[Enter to change]", Style::default().fg(text_secondary()))
         } else {
             Span::raw("")
         },
@@ -259,11 +266,11 @@ fn render_platforms_tab(frame: &mut Frame, model: &Model, area: Rect) {
         let checkbox = if is_enabled { "[x]" } else { "[ ]" };
 
         let line_style = if is_selected {
-            Style::default().fg(TEXT_PRIMARY).bg(PURPLE_ACCENT)
+            Style::default().fg(text_primary()).bg(accent())
         } else if is_enabled {
-            Style::default().fg(TEXT_PRIMARY)
+            Style::default().fg(text_primary())
         } else {
-            Style::default().fg(TEXT_DIMMED)
+            Style::default().fg(text_dimmed())
         };
 
         platform_lines.push(Line::from(Span::styled(
@@ -289,10 +296,10 @@ fn render_platforms_tab(frame: &mut Frame, model: &Model, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(PURPLE_ACCENT))
+                .border_style(Style::default().fg(accent()))
                 .title(Span::styled(
                     " Enabled Platforms ",
-                    Style::default().fg(PURPLE_LIGHT),
+                    Style::default().fg(primary_light()),
                 )),
         )
         .scroll((scroll_offset, 0));
@@ -300,7 +307,7 @@ fn render_platforms_tab(frame: &mut Frame, model: &Model, area: Rect) {
 
     let help = Paragraph::new(Line::from(Span::styled(
         "[Enter] Toggle  [Tab] Switch tab  [Esc] Close",
-        Style::default().fg(TEXT_SECONDARY),
+        Style::default().fg(text_secondary()),
     )));
     frame.render_widget(help, chunks[2]);
 }
@@ -317,7 +324,7 @@ fn render_advanced_tab(frame: &mut Frame, model: &Model, area: Rect) {
 
     let desc = Paragraph::new(Line::from(Span::styled(
         "Default sort and performance settings:",
-        Style::default().fg(TEXT_SECONDARY),
+        Style::default().fg(text_secondary()),
     )));
     frame.render_widget(desc, chunks[0]);
 
@@ -345,26 +352,26 @@ fn render_advanced_tab(frame: &mut Frame, model: &Model, area: Rect) {
         let is_selected = model.options.advanced_list_index == i;
 
         let line_style = if is_selected {
-            Style::default().fg(TEXT_PRIMARY).bg(BG_HIGHLIGHT)
+            Style::default().fg(text_primary()).bg(bg_highlight())
         } else {
-            Style::default().fg(TEXT_PRIMARY)
+            Style::default().fg(text_primary())
         };
 
         let value_style = if is_selected {
             Style::default()
-                .fg(PURPLE_LIGHT)
-                .bg(BG_HIGHLIGHT)
+                .fg(primary_light())
+                .bg(bg_highlight())
                 .add_modifier(Modifier::BOLD)
         } else {
             Style::default()
-                .fg(PURPLE_LIGHT)
+                .fg(primary_light())
                 .add_modifier(Modifier::BOLD)
         };
 
         let desc_style = if is_selected {
-            Style::default().fg(TEXT_SECONDARY).bg(BG_HIGHLIGHT)
+            Style::default().fg(text_secondary()).bg(bg_highlight())
         } else {
-            Style::default().fg(TEXT_SECONDARY)
+            Style::default().fg(text_secondary())
         };
 
         setting_lines.push(Line::from(vec![
@@ -377,10 +384,10 @@ fn render_advanced_tab(frame: &mut Frame, model: &Model, area: Rect) {
     let settings_list = Paragraph::new(setting_lines).block(
         Block::default()
             .borders(Borders::ALL)
-            .border_style(Style::default().fg(PURPLE_ACCENT))
+            .border_style(Style::default().fg(accent()))
             .title(Span::styled(
                 " Settings ",
-                Style::default().fg(PURPLE_LIGHT),
+                Style::default().fg(primary_light()),
             )),
     );
     frame.render_widget(settings_list, chunks[1]);
@@ -388,14 +395,87 @@ fn render_advanced_tab(frame: &mut Frame, model: &Model, area: Rect) {
     let help_lines = vec![
         Line::from(Span::styled(
             "[Enter] Cycle  [s] Direction  [Tab] Switch tab",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         )),
         Line::from(Span::styled(
             "[Esc] Close",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         )),
     ];
     let help = Paragraph::new(help_lines);
+    frame.render_widget(help, chunks[2]);
+}
+
+fn render_theme_tab(frame: &mut Frame, model: &Model, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(2),
+        ])
+        .split(area);
+
+    let desc = Paragraph::new(Line::from(Span::styled(
+        "Select a color theme:",
+        Style::default().fg(text_secondary()),
+    )));
+    frame.render_widget(desc, chunks[0]);
+
+    let mut theme_lines: Vec<Line> = Vec::new();
+    for (i, theme) in Theme::ALL.iter().enumerate() {
+        let is_selected = model.options.theme_list_index == i;
+        let is_current = model.options.theme == *theme;
+
+        let marker = if is_current { "●" } else { "○" };
+
+        let line_style = if is_selected {
+            Style::default().fg(text_primary()).bg(accent())
+        } else if is_current {
+            Style::default().fg(primary_light())
+        } else {
+            Style::default().fg(text_primary())
+        };
+
+        // Show color preview swatches including background colors
+        let p = theme.palette();
+        let preview = Line::from(vec![
+            Span::styled(format!(" {} {:<20}", marker, theme.name()), line_style),
+            Span::styled("██", Style::default().fg(p.bg)),
+            Span::styled("██", Style::default().fg(p.bg_highlight)),
+            Span::styled("██", Style::default().fg(p.primary)),
+            Span::styled("██", Style::default().fg(p.green)),
+            Span::styled("██", Style::default().fg(p.yellow)),
+            Span::styled("██", Style::default().fg(p.accent)),
+        ]);
+        theme_lines.push(preview);
+    }
+
+    // Calculate scroll offset
+    let visible_height = chunks[1].height.saturating_sub(2) as usize;
+    let scroll_offset = if model.options.theme_list_index >= visible_height {
+        (model.options.theme_list_index - visible_height + 1) as u16
+    } else {
+        0
+    };
+
+    let theme_list = Paragraph::new(theme_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(accent()))
+                .title(Span::styled(
+                    " Theme ",
+                    Style::default().fg(primary_light()),
+                )),
+        )
+        .scroll((scroll_offset, 0));
+    frame.render_widget(theme_list, chunks[1]);
+
+    let help = Paragraph::new(Line::from(Span::styled(
+        "[Enter] Select  [Tab] Switch tab  [Esc] Close",
+        Style::default().fg(text_secondary()),
+    )));
     frame.render_widget(help, chunks[2]);
 }
 
@@ -429,15 +509,15 @@ pub fn render_keybinds_popup(frame: &mut Frame) {
     ];
 
     let popup = Paragraph::new(content.join("\n"))
-        .style(Style::default().fg(TEXT_PRIMARY))
+        .style(Style::default().fg(text_primary()))
         .block(
             Block::default()
                 .title(Span::styled(
                     " Keybinds ",
-                    Style::default().fg(PURPLE_LIGHT),
+                    Style::default().fg(primary_light()),
                 ))
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(PURPLE_PRIMARY)),
+                .border_style(Style::default().fg(primary())),
         );
 
     frame.render_widget(popup, popup_area);
@@ -458,10 +538,10 @@ pub fn render_platform_popup(frame: &mut Frame, model: &Model) {
     let block = Block::default()
         .title(Span::styled(
             " Select Platform ",
-            Style::default().fg(PURPLE_LIGHT),
+            Style::default().fg(primary_light()),
         ))
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PURPLE_ACCENT));
+        .border_style(Style::default().fg(accent()));
     frame.render_widget(block, popup_area);
 
     let inner = Rect::new(
@@ -483,11 +563,11 @@ pub fn render_platform_popup(frame: &mut Frame, model: &Model) {
 
         let marker = if is_current { "●" } else { "○" };
         let line_style = if is_selected {
-            Style::default().fg(TEXT_PRIMARY).bg(PURPLE_ACCENT)
+            Style::default().fg(text_primary()).bg(accent())
         } else if is_current {
-            Style::default().fg(PURPLE_LIGHT)
+            Style::default().fg(primary_light())
         } else {
-            Style::default().fg(TEXT_PRIMARY)
+            Style::default().fg(text_primary())
         };
 
         platform_lines.push(Line::from(Span::styled(
@@ -509,7 +589,7 @@ pub fn render_platform_popup(frame: &mut Frame, model: &Model) {
 
     let help = Paragraph::new(Line::from(Span::styled(
         "[Enter] Select  [Esc] Cancel",
-        Style::default().fg(TEXT_SECONDARY),
+        Style::default().fg(text_secondary()),
     )));
     frame.render_widget(help, chunks[1]);
 }
@@ -527,10 +607,10 @@ pub fn render_price_filter_popup(frame: &mut Frame, model: &Model) {
     let block = Block::default()
         .title(Span::styled(
             " Price Filter ",
-            Style::default().fg(PURPLE_LIGHT),
+            Style::default().fg(primary_light()),
         ))
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(PURPLE_ACCENT));
+        .border_style(Style::default().fg(accent()));
     frame.render_widget(block, popup_area);
 
     let inner = Rect::new(
@@ -544,15 +624,15 @@ pub fn render_price_filter_popup(frame: &mut Frame, model: &Model) {
     let max_selected = model.price_filter.selected_field == 1;
 
     let min_style = if min_selected {
-        Style::default().fg(TEXT_PRIMARY).bg(PURPLE_ACCENT)
+        Style::default().fg(text_primary()).bg(accent())
     } else {
-        Style::default().fg(TEXT_PRIMARY)
+        Style::default().fg(text_primary())
     };
 
     let max_style = if max_selected {
-        Style::default().fg(TEXT_PRIMARY).bg(PURPLE_ACCENT)
+        Style::default().fg(text_primary()).bg(accent())
     } else {
-        Style::default().fg(TEXT_PRIMARY)
+        Style::default().fg(text_primary())
     };
 
     let min_cursor = if min_selected { "▋" } else { "" };
@@ -563,22 +643,22 @@ pub fn render_price_filter_popup(frame: &mut Frame, model: &Model) {
 
     let content = vec![
         Line::from(vec![
-            Span::styled("Min: ", Style::default().fg(PURPLE_LIGHT)),
+            Span::styled("Min: ", Style::default().fg(primary_light())),
             Span::styled(format!("{:<10}", min_display), min_style),
         ]),
         Line::from(""),
         Line::from(vec![
-            Span::styled("Max: ", Style::default().fg(PURPLE_LIGHT)),
+            Span::styled("Max: ", Style::default().fg(primary_light())),
             Span::styled(format!("{:<10}", max_display), max_style),
         ]),
         Line::from(""),
         Line::from(Span::styled(
             "[Tab] Switch  [Enter] Apply",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         )),
         Line::from(Span::styled(
             "[c] Clear  [Esc] Cancel",
-            Style::default().fg(TEXT_SECONDARY),
+            Style::default().fg(text_secondary()),
         )),
     ];
 

--- a/tui/src/view/price_chart.rs
+++ b/tui/src/view/price_chart.rs
@@ -10,10 +10,18 @@ use super::styles::*;
 use crate::model::Model;
 
 pub fn render_price_chart(frame: &mut Frame, model: &Model, area: Rect, dimmed: bool) {
-    let text_color = if dimmed { TEXT_DIMMED } else { TEXT_SECONDARY };
-    let border_color = if dimmed { TEXT_DIMMED } else { PURPLE_ACCENT };
-    let title_color = if dimmed { TEXT_DIMMED } else { TEXT_PRIMARY };
-    let chart_color = if dimmed { TEXT_DIMMED } else { ACCENT_GREEN };
+    let text_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_secondary()
+    };
+    let border_color = if dimmed { text_dimmed() } else { accent() };
+    let title_color = if dimmed {
+        text_dimmed()
+    } else {
+        text_primary()
+    };
+    let chart_color = if dimmed { text_dimmed() } else { green() };
 
     let title = build_title("Price History (1 year)", border_color, title_color);
     let block = Block::default()
@@ -58,17 +66,17 @@ pub fn render_price_chart(frame: &mut Frame, model: &Model, area: Rect, dimmed: 
         let summary = Line::from(vec![
             Span::styled(
                 format!("Low: {}{:.2}", currency, min_price),
-                Style::default().fg(ACCENT_GREEN),
+                Style::default().fg(green()),
             ),
             Span::styled("  ", Style::default()),
             Span::styled(
                 format!("High: {}{:.2}", currency, max_price),
-                Style::default().fg(ACCENT_YELLOW),
+                Style::default().fg(yellow()),
             ),
             Span::styled("  ", Style::default()),
             Span::styled(
                 format!("Now: {}{:.2}", currency, current_price),
-                Style::default().fg(TEXT_PRIMARY),
+                Style::default().fg(text_primary()),
             ),
         ]);
         frame.render_widget(Paragraph::new(summary), chunks[0]);

--- a/tui/src/view/price_chart.rs
+++ b/tui/src/view/price_chart.rs
@@ -63,20 +63,27 @@ pub fn render_price_chart(frame: &mut Frame, model: &Model, area: Rect, dimmed: 
             .split(inner);
 
         // Summary line
+        let low_color = if dimmed { text_dimmed() } else { green() };
+        let high_color = if dimmed { text_dimmed() } else { yellow() };
+        let now_color = if dimmed {
+            text_dimmed()
+        } else {
+            text_primary()
+        };
         let summary = Line::from(vec![
             Span::styled(
                 format!("Low: {}{:.2}", currency, min_price),
-                Style::default().fg(green()),
+                Style::default().fg(low_color),
             ),
             Span::styled("  ", Style::default()),
             Span::styled(
                 format!("High: {}{:.2}", currency, max_price),
-                Style::default().fg(yellow()),
+                Style::default().fg(high_color),
             ),
             Span::styled("  ", Style::default()),
             Span::styled(
                 format!("Now: {}{:.2}", currency, current_price),
-                Style::default().fg(text_primary()),
+                Style::default().fg(now_color),
             ),
         ]);
         frame.render_widget(Paragraph::new(summary), chunks[0]);

--- a/tui/src/view/styles.rs
+++ b/tui/src/view/styles.rs
@@ -3,19 +3,270 @@ use ratatui::{
     text::{Line, Span},
 };
 
-// Dealve color palette - Pastel theme (light colors for dark background)
-pub const PURPLE_PRIMARY: Color = Color::Rgb(200, 160, 255); // Pastel lavender - main brand color
-pub const PURPLE_LIGHT: Color = Color::Rgb(220, 190, 255); // Lighter pastel lavender - highlights
-pub const PURPLE_ACCENT: Color = Color::Rgb(180, 130, 255); // Slightly stronger pastel for accents
-pub const SHORTCUT_KEY: Color = Color::Rgb(255, 120, 200); // Pink/magenta for shortcut keys (btop style)
-pub const ACCENT_GREEN: Color = Color::Rgb(150, 230, 150); // Pastel mint green - good deals
-pub const ACCENT_YELLOW: Color = Color::Rgb(255, 230, 150); // Pastel gold/cream - medium deals
-pub const TEXT_PRIMARY: Color = Color::White;
-pub const TEXT_SECONDARY: Color = Color::Rgb(180, 180, 180); // Light gray
-pub const TEXT_DIMMED: Color = Color::Rgb(90, 90, 90); // Dimmed text for background when menu open
-pub const BG_DARK: Color = Color::Rgb(20, 15, 30); // Very dark purple background
-pub const BG_HIGHLIGHT: Color = Color::Rgb(60, 45, 90); // Darker purple for selection highlight
-pub const ERROR_RED: Color = Color::Rgb(255, 120, 120);
+// Theme system
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ThemePalette {
+    pub primary: Color,
+    pub primary_light: Color,
+    pub accent: Color,
+    pub shortcut_key: Color,
+    pub green: Color,
+    pub yellow: Color,
+    pub text: Color,
+    pub text_secondary: Color,
+    pub text_dimmed: Color,
+    pub bg: Color,
+    pub bg_highlight: Color,
+    pub error: Color,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Theme {
+    #[default]
+    Default,
+    CatppuccinLatte,
+    TokyoNight,
+    Dracula,
+    Gruvbox,
+    Nord,
+    OneDark,
+    SolarizedDark,
+    SolarizedLight,
+}
+
+impl Theme {
+    pub const ALL: &'static [Theme] = &[
+        Theme::Default,
+        Theme::CatppuccinLatte,
+        Theme::TokyoNight,
+        Theme::Dracula,
+        Theme::Gruvbox,
+        Theme::Nord,
+        Theme::OneDark,
+        Theme::SolarizedDark,
+        Theme::SolarizedLight,
+    ];
+
+    pub fn name(&self) -> &str {
+        match self {
+            Theme::Default => "Default",
+            Theme::CatppuccinLatte => "Catppuccin Latte",
+            Theme::TokyoNight => "Tokyo Night",
+            Theme::Dracula => "Dracula",
+            Theme::Gruvbox => "Gruvbox",
+            Theme::Nord => "Nord",
+            Theme::OneDark => "One Dark",
+            Theme::SolarizedDark => "Solarized Dark",
+            Theme::SolarizedLight => "Solarized Light",
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        match self {
+            Theme::Default => "default",
+            Theme::CatppuccinLatte => "catppuccin-latte",
+            Theme::TokyoNight => "tokyo-night",
+            Theme::Dracula => "dracula",
+            Theme::Gruvbox => "gruvbox",
+            Theme::Nord => "nord",
+            Theme::OneDark => "one-dark",
+            Theme::SolarizedDark => "solarized-dark",
+            Theme::SolarizedLight => "solarized-light",
+        }
+    }
+
+    pub fn from_id(id: &str) -> Option<Theme> {
+        Theme::ALL.iter().find(|t| t.id() == id).copied()
+    }
+
+    pub fn palette(&self) -> ThemePalette {
+        match self {
+            Theme::Default => ThemePalette {
+                primary: Color::Rgb(200, 160, 255),
+                primary_light: Color::Rgb(220, 190, 255),
+                accent: Color::Rgb(180, 130, 255),
+                shortcut_key: Color::Rgb(255, 120, 200),
+                green: Color::Rgb(150, 230, 150),
+                yellow: Color::Rgb(255, 230, 150),
+                text: Color::White,
+                text_secondary: Color::Rgb(180, 180, 180),
+                text_dimmed: Color::Rgb(90, 90, 90),
+                bg: Color::Rgb(20, 15, 30),
+                bg_highlight: Color::Rgb(60, 45, 90),
+                error: Color::Rgb(255, 120, 120),
+            },
+            Theme::CatppuccinLatte => ThemePalette {
+                primary: Color::Rgb(136, 57, 239),         // mauve
+                primary_light: Color::Rgb(220, 138, 120),  // rosewater
+                accent: Color::Rgb(30, 102, 245),          // blue
+                shortcut_key: Color::Rgb(223, 142, 29),    // yellow
+                green: Color::Rgb(64, 160, 43),            // green
+                yellow: Color::Rgb(223, 142, 29),          // yellow
+                text: Color::Rgb(76, 79, 105),             // text
+                text_secondary: Color::Rgb(108, 111, 133), // subtext0
+                text_dimmed: Color::Rgb(172, 176, 190),    // surface2
+                bg: Color::Rgb(239, 241, 245),             // base
+                bg_highlight: Color::Rgb(204, 208, 218),   // surface0
+                error: Color::Rgb(210, 15, 57),            // red
+            },
+            Theme::TokyoNight => ThemePalette {
+                primary: Color::Rgb(187, 154, 247), // purple
+                primary_light: Color::Rgb(199, 175, 247),
+                accent: Color::Rgb(122, 162, 247),       // blue
+                shortcut_key: Color::Rgb(224, 175, 104), // orange
+                green: Color::Rgb(158, 206, 106),        // green
+                yellow: Color::Rgb(224, 175, 104),       // orange
+                text: Color::Rgb(192, 202, 245),         // fg
+                text_secondary: Color::Rgb(134, 150, 190),
+                text_dimmed: Color::Rgb(65, 72, 104), // comment
+                bg: Color::Rgb(26, 27, 38),           // bg
+                bg_highlight: Color::Rgb(41, 46, 66), // bg_highlight
+                error: Color::Rgb(247, 118, 142),     // red
+            },
+            Theme::Dracula => ThemePalette {
+                primary: Color::Rgb(189, 147, 249),       // purple
+                primary_light: Color::Rgb(255, 121, 198), // pink
+                accent: Color::Rgb(139, 233, 253),        // cyan
+                shortcut_key: Color::Rgb(255, 184, 108),  // orange
+                green: Color::Rgb(80, 250, 123),          // green
+                yellow: Color::Rgb(241, 250, 140),        // yellow
+                text: Color::Rgb(248, 248, 242),          // fg
+                text_secondary: Color::Rgb(189, 193, 207),
+                text_dimmed: Color::Rgb(98, 114, 164), // comment
+                bg: Color::Rgb(40, 42, 54),            // bg
+                bg_highlight: Color::Rgb(68, 71, 90),  // current_line
+                error: Color::Rgb(255, 85, 85),        // red
+            },
+            Theme::Gruvbox => ThemePalette {
+                primary: Color::Rgb(211, 134, 155),        // purple
+                primary_light: Color::Rgb(235, 219, 178),  // fg
+                accent: Color::Rgb(131, 165, 152),         // aqua
+                shortcut_key: Color::Rgb(254, 128, 25),    // orange
+                green: Color::Rgb(184, 187, 38),           // green
+                yellow: Color::Rgb(250, 189, 47),          // yellow
+                text: Color::Rgb(235, 219, 178),           // fg
+                text_secondary: Color::Rgb(189, 174, 147), // fg3
+                text_dimmed: Color::Rgb(102, 92, 84),      // bg4
+                bg: Color::Rgb(40, 40, 40),                // bg
+                bg_highlight: Color::Rgb(60, 56, 54),      // bg1
+                error: Color::Rgb(251, 73, 52),            // red
+            },
+            Theme::Nord => ThemePalette {
+                primary: Color::Rgb(180, 142, 173),        // purple (nord15)
+                primary_light: Color::Rgb(216, 222, 233),  // snow storm
+                accent: Color::Rgb(129, 161, 193),         // frost blue (nord9)
+                shortcut_key: Color::Rgb(208, 135, 112),   // aurora orange (nord12)
+                green: Color::Rgb(163, 190, 140),          // aurora green (nord14)
+                yellow: Color::Rgb(235, 203, 139),         // aurora yellow (nord13)
+                text: Color::Rgb(236, 239, 244),           // snow storm (nord6)
+                text_secondary: Color::Rgb(216, 222, 233), // snow storm (nord4)
+                text_dimmed: Color::Rgb(76, 86, 106),      // polar night (nord3)
+                bg: Color::Rgb(46, 52, 64),                // polar night (nord0)
+                bg_highlight: Color::Rgb(59, 66, 82),      // polar night (nord1)
+                error: Color::Rgb(191, 97, 106),           // aurora red (nord11)
+            },
+            Theme::OneDark => ThemePalette {
+                primary: Color::Rgb(198, 120, 221), // purple
+                primary_light: Color::Rgb(224, 175, 234),
+                accent: Color::Rgb(97, 175, 239),        // blue
+                shortcut_key: Color::Rgb(209, 154, 102), // orange
+                green: Color::Rgb(152, 195, 121),        // green
+                yellow: Color::Rgb(229, 192, 123),       // yellow
+                text: Color::Rgb(171, 178, 191),         // fg
+                text_secondary: Color::Rgb(139, 145, 157),
+                text_dimmed: Color::Rgb(76, 82, 99), // comment
+                bg: Color::Rgb(40, 44, 52),          // bg
+                bg_highlight: Color::Rgb(50, 56, 66),
+                error: Color::Rgb(224, 108, 117), // red
+            },
+            Theme::SolarizedDark => ThemePalette {
+                primary: Color::Rgb(108, 113, 196),        // violet
+                primary_light: Color::Rgb(147, 161, 161),  // base1
+                accent: Color::Rgb(38, 139, 210),          // blue
+                shortcut_key: Color::Rgb(203, 75, 22),     // orange
+                green: Color::Rgb(133, 153, 0),            // green
+                yellow: Color::Rgb(181, 137, 0),           // yellow
+                text: Color::Rgb(131, 148, 150),           // base0
+                text_secondary: Color::Rgb(101, 123, 131), // base00
+                text_dimmed: Color::Rgb(7, 54, 66),        // base02
+                bg: Color::Rgb(0, 43, 54),                 // base03
+                bg_highlight: Color::Rgb(7, 54, 66),       // base02
+                error: Color::Rgb(220, 50, 47),            // red
+            },
+            Theme::SolarizedLight => ThemePalette {
+                primary: Color::Rgb(108, 113, 196),        // violet
+                primary_light: Color::Rgb(88, 110, 117),   // base01
+                accent: Color::Rgb(38, 139, 210),          // blue
+                shortcut_key: Color::Rgb(203, 75, 22),     // orange
+                green: Color::Rgb(133, 153, 0),            // green
+                yellow: Color::Rgb(181, 137, 0),           // yellow
+                text: Color::Rgb(101, 123, 131),           // base00
+                text_secondary: Color::Rgb(131, 148, 150), // base0
+                text_dimmed: Color::Rgb(198, 205, 203),    // base2
+                bg: Color::Rgb(253, 246, 227),             // base3
+                bg_highlight: Color::Rgb(238, 232, 213),   // base2
+                error: Color::Rgb(220, 50, 47),            // red
+            },
+        }
+    }
+}
+
+// Active theme (global)
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static ACTIVE_THEME_INDEX: AtomicUsize = AtomicUsize::new(0);
+
+pub fn set_active_theme(theme: Theme) {
+    let idx = Theme::ALL.iter().position(|t| *t == theme).unwrap_or(0);
+    ACTIVE_THEME_INDEX.store(idx, Ordering::Relaxed);
+}
+
+pub fn active_theme() -> Theme {
+    let idx = ACTIVE_THEME_INDEX.load(Ordering::Relaxed);
+    Theme::ALL[idx]
+}
+
+pub fn palette() -> ThemePalette {
+    active_theme().palette()
+}
+
+// Convenience color accessors
+pub fn primary() -> Color {
+    palette().primary
+}
+pub fn primary_light() -> Color {
+    palette().primary_light
+}
+pub fn accent() -> Color {
+    palette().accent
+}
+pub fn shortcut_key() -> Color {
+    palette().shortcut_key
+}
+pub fn green() -> Color {
+    palette().green
+}
+pub fn yellow() -> Color {
+    palette().yellow
+}
+pub fn text_primary() -> Color {
+    palette().text
+}
+pub fn text_secondary() -> Color {
+    palette().text_secondary
+}
+pub fn text_dimmed() -> Color {
+    palette().text_dimmed
+}
+pub fn bg_dark() -> Color {
+    palette().bg
+}
+pub fn bg_highlight() -> Color {
+    palette().bg_highlight
+}
+pub fn error_red() -> Color {
+    palette().error
+}
 
 pub const ASCII_LOGO: [&str; 6] = [
     "██████╗ ███████╗ █████╗ ██╗    ██╗   ██╗███████╗",


### PR DESCRIPTION
## Description

<!-- What does this PR do? -->

Replace hardcoded color palette with a theme system supporting Default,
Catppuccin Latte, Tokyo Night, Dracula, Gruvbox, Nord, One Dark, and
Solarized (Dark/Light). Theme selection is available in the Options popup
under a new "Theme" tab and persisted to config.json.


## Related issues

Closes #4 

<img width="912" height="789" alt="image" src="https://github.com/user-attachments/assets/fd3ec746-764f-477e-8d72-334f91fd6bd7" />

## Checklist

- [x] Code compiles without warnings (`cargo clippy`)
- [x] Code is formatted (`cargo fmt`)
- [x] I have tested the changes locally
